### PR TITLE
Added pentesting utilities

### DIFF
--- a/scripts/distro/postSetup
+++ b/scripts/distro/postSetup
@@ -63,5 +63,6 @@ echo "[[ -f ~/.lug-bashrc ]] && source ~/.lug-bashrc " >> ~/.bashrc
 # Pentesting tools/packages
 echo "Installing penetration testing utilities...\n"
 yay -S nmap zenmap metasploit hashcat john wifite burpsuite wireshark-cli wireshark-qt social-engineering-toolkit ngrok aircrack-ng sqlite
-# Pyphisher's not on AUR
+# Pyphisher's not on AUR, installing it using Pipx
+pipx install pyphisher maxphisher # more feature-complete version by the same author
 # echo >> themeInfo to ~/.config/gtk-3.0/settings.ini

--- a/scripts/distro/postSetup
+++ b/scripts/distro/postSetup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 lolcat $(pwd)/distroInstallerSplash
-echo "Welcome to LugOS..." # insert content here
+echo "Welcome to LugOS...\n" # insert content here
 
 # Your host distro will be installed as a strata by design, so one of the 2 lines below will error out; this is undesirable behaviour.
   
@@ -47,7 +47,7 @@ for extension in "${extensions[@]}"; do
   gext install "$extension"
 done
 
-echo "Setting up the AUR helper.."
+echo "Setting up the AUR helper...\n"
 ../terminal/setup-yay 
 # add paru=yay=pacman thru (fish) shell aliases
 yay -S sassc gnome-shell-extension-extension-list xorg-xrandr --needed --noconfirm # neofetch not required
@@ -60,4 +60,8 @@ ln -sf $(pwd)/../neofetch/config.conf ~/.config/neofetch/
 ln -sf $(pwd)/../terminal/.bashrc ~/.lug-bashrc
 echo "[[ -f ~/.lug-bashrc ]] && source ~/.lug-bashrc " >> ~/.bashrc
 
+# Pentesting tools/packages
+echo "Installing penetration testing utilities...\n"
+yay -S nmap zenmap metasploit hashcat john wifite burpsuite wireshark-cli wireshark-qt social-engineering-toolkit ngrok aircrack-ng sqlite
+# Pyphisher's not on AUR
 # echo >> themeInfo to ~/.config/gtk-3.0/settings.ini


### PR DESCRIPTION
Pyphisher's not available on the AUR, or probably on any standard repo. We might have to use a virtualenv to install it.